### PR TITLE
Add repository, homepage, issues, and keywords fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,14 @@
     "pub:dry": "./bin/verpub publish --dry-run",
     "test": "./test/test.sh"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gcaufy/verpub/"
+  },
+  "bugs": "https://github.com/Gcaufy/verpub/issues",
+  "homepage": "https://github.com/Gcaufy/verpub/",
   "author": "Gcaufy <gcaufy@gmail.com>",
+  "keywords": ["semver", "publish", "version"],
   "license": "MIT",
   "dependencies": {
     "commander": "^3.0.1",


### PR DESCRIPTION
Used by npmjs.com for auto-creating links back to your repo, etc.

Would also be good to put `"engines": {"node": ">=6.0.0"}` or whatever Node versions you support.