### PR TITLE
Fix lgtm-reported security issue

### DIFF
--- a/lib/verpub.js
+++ b/lib/verpub.js
@@ -167,7 +167,7 @@ exports = module.exports = class VerPub {
             replaceFiles(
               this.logger,
               this.opt.files,
-              new RegExp(pkg.version.replace(/\./g, '\\.'), 'g'),
+              new RegExp(pkg.version.replace(/\\/g, '\\\\').replace(/\./g, '\\.'), 'g'),
               params.version
             );
           }


### PR DESCRIPTION
Backslashes need escaping when producing an escape adding backslashes.

See https://lgtm.com/projects/g/Gcaufy/verpub/?mode=list