### PR TITLE
feat: 支持自定义commit信息(增加后缀和信息全自定义两种方式)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .vscode/
+.idea/

--- a/bin/cmd/publish.js
+++ b/bin/cmd/publish.js
@@ -150,7 +150,9 @@ module.exports = function(name, opt) {
         version: opt.version && typeof opt.version === 'string' ? opt.version : '',
         interact: false,
         dryRun: opt.dryRun,
-        desc: opt.desc
+        desc: opt.desc,
+        commitMsg: opt.commitMsg,
+        commitSuffix: opt.commitSuffix
       },
       opt.increase ? { increase: opt.increase } : {}
     );

--- a/bin/cmd/publish.js
+++ b/bin/cmd/publish.js
@@ -151,8 +151,7 @@ module.exports = function(name, opt) {
         interact: false,
         dryRun: opt.dryRun,
         desc: opt.desc,
-        commitMsg: opt.commitMsg,
-        commitSuffix: opt.commitSuffix
+        customizeCommit: opt.customizeCommit
       },
       opt.increase ? { increase: opt.increase } : {}
     );

--- a/lib/verpub.js
+++ b/lib/verpub.js
@@ -26,8 +26,9 @@ const DEFAULT_OPT = {
   tag: '{name}@{version}',
   debug: false,
   desc: '',
-  commitMsg: '', // 自定义commitMsg
-  commitSuffix: '' // 自定义commit后缀信息
+  customizeCommit: tag => {
+    return `release: ${tag}`;
+  } // 自定义 commitMsg 方法
 };
 
 function tryLoad(file) {
@@ -141,8 +142,6 @@ exports = module.exports = class VerPub {
     params = Object.assign({}, this.opt.minIncrease || {}, params);
 
     let desc = params.desc;
-    let commitMsg = params.commitMsg;
-    let commitSuffix = params.commitSuffix;
 
     if (params.pkg) {
       params.name = params.pkg.name;
@@ -200,7 +199,10 @@ exports = module.exports = class VerPub {
             this.executer
               .gitadd(changedFiles)
               .then(() => {
-                const commitInfo = commitMsg ? commitMsg : `release:  ${tag}${commitSuffix ? commitSuffix : ''}`;
+                const commitInfo =
+                  typeof params.customizeCommit === 'function'
+                    ? params.customizeCommit(tag)
+                    : DEFAULT_OPT.customizeCommit(tag);
                 return this.executer.gitcommit(commitInfo);
               })
               .then(() => {

--- a/lib/verpub.js
+++ b/lib/verpub.js
@@ -25,7 +25,9 @@ const DEFAULT_OPT = {
   },
   tag: '{name}@{version}',
   debug: false,
-  desc: ''
+  desc: '',
+  commitMsg: '', // 自定义commitMsg
+  commitSuffix: '' // 自定义commit后缀信息
 };
 
 function tryLoad(file) {
@@ -139,6 +141,8 @@ exports = module.exports = class VerPub {
     params = Object.assign({}, this.opt.minIncrease || {}, params);
 
     let desc = params.desc;
+    let commitMsg = params.commitMsg;
+    let commitSuffix = params.commitSuffix;
 
     if (params.pkg) {
       params.name = params.pkg.name;
@@ -196,7 +200,8 @@ exports = module.exports = class VerPub {
             this.executer
               .gitadd(changedFiles)
               .then(() => {
-                return this.executer.gitcommit('release: ' + tag);
+                const commitInfo = commitMsg ? commitMsg : `release:  ${tag}${commitSuffix ? commitSuffix : ''}`;
+                return this.executer.gitcommit(commitInfo);
               })
               .then(() => {
                 return this.executer.gittag(tag, desc);


### PR DESCRIPTION
支持commit信息自定义
1. 支持补充后缀模式，在 release: tag 后增加后缀
2. 支持完全自定义，使用commitMsg 代替 release: tag 信息